### PR TITLE
Write the source version to the build directory

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -15,6 +15,8 @@ fi
 
 rm $build_dir/rev-manifest.json
 rm $build_dir/version.json
+# Capture the git commit hash
+echo $SOURCE_VERSION > $build_dir/release-version.txt
 
 puts_step "Waiting for static assets to be deployed"
 


### PR DESCRIPTION
This will be used for setting the release version for sentry.